### PR TITLE
Pdh 27/jas/basic enemy tweaks and fixes

### DIFF
--- a/Scenes/Enemies/Layer 1/1_fighter.tscn
+++ b/Scenes/Enemies/Layer 1/1_fighter.tscn
@@ -1,7 +1,6 @@
-[gd_scene load_steps=4 format=3 uid="uid://dqw4pg61po5rm"]
+[gd_scene load_steps=3 format=3 uid="uid://dqw4pg61po5rm"]
 
 [ext_resource type="PackedScene" uid="uid://falw5inxb8wt" path="res://Scenes/Enemies/Base/fighter.tscn" id="1_iy6bd"]
-[ext_resource type="Script" path="res://Scripts/stat_component.gd" id="2_lvqlv"]
 [ext_resource type="SpriteFrames" uid="uid://c08824hnc2h8c" path="res://Assets/Enemies/SpriteFrames/1_fighter_frames.tres" id="2_o7aq8"]
 
 [node name="Fighter" instance=ExtResource("1_iy6bd")]
@@ -14,4 +13,10 @@ sprite_frames = ExtResource("2_o7aq8")
 animation = &"attack0_d"
 
 [node name="StatManager" parent="StatComponents" index="0"]
-script = ExtResource("2_lvqlv")
+stat_dict = {
+"ATK": 5,
+"CD": 3,
+"EXP_GAIN": 1,
+"HP": 15,
+"MOVE_SPD": 2
+}

--- a/Scenes/Enemies/Layer 1/1_fighter.tscn
+++ b/Scenes/Enemies/Layer 1/1_fighter.tscn
@@ -20,3 +20,6 @@ stat_dict = {
 "HP": 15,
 "MOVE_SPD": 2
 }
+
+[node name="BasicAttack" parent="StateMachineComponent" index="0"]
+surround = true

--- a/Scenes/Enemies/Layer 1/gagamboy.tscn
+++ b/Scenes/Enemies/Layer 1/gagamboy.tscn
@@ -90,6 +90,7 @@ script = ExtResource("4_gs1pe")
 [node name="ShootProjectiles" type="Node" parent="SkillManagerComponent" index="0" node_paths=PackedStringArray("stat_component")]
 script = ExtResource("5_0ut5g")
 projectile_obj = ExtResource("8_hy7ws")
+spawn_offset = 1.25
 stat_component = NodePath("../../StatComponents/ProjectileStats")
 
 [node name="BullRush" type="Node" parent="SkillManagerComponent" index="1" node_paths=PackedStringArray("stat_component")]

--- a/Scenes/Enemies/reaper.tscn
+++ b/Scenes/Enemies/reaper.tscn
@@ -11,6 +11,8 @@ collision_layer = 0
 [node name="AnimatedSprite3D" parent="." index="1"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 2.26416, 0)
 sprite_frames = ExtResource("2_oquth")
+animation = &"attack"
+autoplay = ""
 frame_progress = 0.328504
 
 [node name="StatManager" parent="StatComponents" index="0"]

--- a/Scenes/boss_health_bar.tscn
+++ b/Scenes/boss_health_bar.tscn
@@ -1,9 +1,26 @@
-[gd_scene load_steps=2 format=3 uid="uid://cwcroypoqwkw7"]
+[gd_scene load_steps=4 format=3 uid="uid://cwcroypoqwkw7"]
 
 [ext_resource type="PackedScene" uid="uid://didk3s6ip6dcs" path="res://Scenes/health_bar.tscn" id="1_mfgvy"]
+[ext_resource type="FontFile" uid="uid://bbyaf4lj3435" path="res://Assets/Font/Minecraft.ttf" id="2_cid36"]
+
+[sub_resource type="LabelSettings" id="LabelSettings_5ldyv"]
+font = ExtResource("2_cid36")
+shadow_size = 2
+shadow_color = Color(0, 0, 0, 0.372549)
 
 [node name="BossHealthBar" instance=ExtResource("1_mfgvy")]
 
 [node name="HealthBar" parent="." index="0"]
 offset_top = 11.0
 offset_bottom = 34.0
+
+[node name="BossLabel" type="Label" parent="." index="3"]
+unique_name_in_owner = true
+offset_left = 345.0
+offset_top = 38.0
+offset_right = 725.0
+offset_bottom = 61.0
+label_settings = SubResource("LabelSettings_5ldyv")
+horizontal_alignment = 1
+vertical_alignment = 1
+uppercase = true

--- a/Scenes/demo_level.tscn
+++ b/Scenes/demo_level.tscn
@@ -498,8 +498,8 @@ navigation = NodePath("../World/LevelNavMesh")
 reaper_scene = ExtResource("13_3hg34")
 reaper_spawn_time = 600.0
 spawn_table = {
-ExtResource("14_7qa7u"): 1,
-ExtResource("21_vkkk4"): 0
+ExtResource("14_7qa7u"): 0,
+ExtResource("21_vkkk4"): 1
 }
 spawn_delay = 2.0
 

--- a/Scenes/demo_level.tscn
+++ b/Scenes/demo_level.tscn
@@ -498,8 +498,8 @@ navigation = NodePath("../World/LevelNavMesh")
 reaper_scene = ExtResource("13_3hg34")
 reaper_spawn_time = 600.0
 spawn_table = {
-ExtResource("14_7qa7u"): 0,
-ExtResource("21_vkkk4"): 1
+ExtResource("14_7qa7u"): 1,
+ExtResource("21_vkkk4"): 0
 }
 spawn_delay = 2.0
 

--- a/Scenes/tentacle_weapon_skill.gd
+++ b/Scenes/tentacle_weapon_skill.gd
@@ -52,8 +52,11 @@ func _start_damage_over_time(health_component: HealthComponent, tentacle):
 
 func _hold_enemy(enemy:Node):
 	var tentacle = tentacle_pool._get_unused_object()
+
+	enemy.movement_component._set_static_movement(true)
 	enemy.movement_component._set_independent_movement(true)
 	enemy.movement_component._set_target_position(enemy.global_position)
+
 	tentacle._move_tentacle(enemy.global_position)
 	tentacle._activate_tentacle(skill_duration)
 	_start_damage_over_time(enemy.health_component, tentacle)
@@ -63,4 +66,5 @@ func _hold_enemy(enemy:Node):
 		_release_enemy(enemy)
 
 func _release_enemy(enemy:Node):
+	enemy.movement_component._set_static_movement(false)
 	enemy.movement_component._set_independent_movement(false)

--- a/Scripts/Skills/devour.gd
+++ b/Scripts/Skills/devour.gd
@@ -26,6 +26,7 @@ var temples:Array = []
 var positions:Array = []
 var a_pattern_positions:Array = []
 var b_pattern_positions:Array = []
+var aoe_y_offset:float = 0.8
 
 func _ready():
 	_get_values()
@@ -135,7 +136,9 @@ func _execute_pattern(is_pattern_a:bool, is_marker:bool):
 			bite_marker._set_target_position(next_pos)
 			await get_tree().create_timer(cd).timeout
 		else:
-			devour_aoe._move_to_position(next_pos)
+			var aoe_pos = next_pos
+			aoe_pos.y -= aoe_y_offset
+			devour_aoe._move_to_position(aoe_pos)
 			await get_tree().create_timer(1).timeout
 			_set_target_position(next_pos)
 			await get_tree().create_timer(cd - 1).timeout

--- a/Scripts/Skills/shoot_projectiles.gd
+++ b/Scripts/Skills/shoot_projectiles.gd
@@ -2,6 +2,7 @@ extends "res://Scripts/skill_component.gd"
 class_name ShootProjectiles
 
 @export var projectile_obj:PackedScene
+@export var spawn_offset:float = 0
 
 var projectile_count:int = 1
 var cd:float = 0
@@ -58,7 +59,11 @@ func _physics_process(_delta: float):
 func _start_projectiles():
 	can_activate = false
 	var projectile_node = get_parent().parent_component
-	var direction = Constants._get_direction(target.global_transform.origin, projectile_node.global_transform.origin)
+
+	var direction_to_player = (target.global_transform.origin - projectile_node.global_transform.origin).normalized()
+	var projectile_launch_pos = projectile_node.global_transform.origin + direction_to_player *  spawn_offset
+
+	var direction = Constants._get_direction(target.global_transform.origin, projectile_launch_pos)
 	# Store base direction in case there's multiple projectiles
 	var base_direction = direction
 
@@ -82,10 +87,10 @@ func _start_projectiles():
 			else:
 				direction = base_direction
 
-			_spawn_projectile(projectile_node.global_transform.origin, target, direction)
+			_spawn_projectile(projectile_launch_pos, target, direction)
 	# Else, just spawn one normally
 	else:
-		_spawn_projectile(projectile_node.global_transform.origin, target, direction)
+		_spawn_projectile(projectile_launch_pos, target, direction)
 
 	# Await for cd interval before looping and creating another instance
 	await get_tree().create_timer(cd).timeout

--- a/Scripts/States/bomber_basic_state.gd
+++ b/Scripts/States/bomber_basic_state.gd
@@ -9,7 +9,7 @@ func enter():
 	skill_manager._change_skill(0)
 
 	# Set with simple following
-	movement_manager._set_surround(false)
+	movement_manager._set_surround(true)
 	movement_manager._set_stay_in_range(true, 1)
 	movement_manager._state_moving(true)
 

--- a/Scripts/States/fighter_basic_state.gd
+++ b/Scripts/States/fighter_basic_state.gd
@@ -1,5 +1,6 @@
 extends Node
 
+@export var surround:bool = false
 var fsm: StateMachine
 var movement_manager
 var skill_manager
@@ -10,7 +11,7 @@ func enter():
 	skill_manager._change_skill(0)
 	skill_manager._state_attacking(true)
 
-	movement_manager._set_surround(true)
+	movement_manager._set_surround(surround)
 	movement_manager._set_stay_in_range(true, 1)
 	movement_manager._state_moving(true)
 

--- a/Scripts/States/fighter_basic_state.gd
+++ b/Scripts/States/fighter_basic_state.gd
@@ -10,7 +10,7 @@ func enter():
 	skill_manager._change_skill(0)
 	skill_manager._state_attacking(true)
 
-	movement_manager._set_surround(false)
+	movement_manager._set_surround(true)
 	movement_manager._set_stay_in_range(true, 1)
 	movement_manager._state_moving(true)
 

--- a/Scripts/States/trapper_basic_state.gd
+++ b/Scripts/States/trapper_basic_state.gd
@@ -9,7 +9,7 @@ func enter():
 	skill_manager._change_skill(0)
 
 	# Start moving
-	movement_manager._set_surround(false)
+	movement_manager._set_surround(true)
 	movement_manager._set_stay_in_range(true, 1)
 	movement_manager._state_moving(true)
 

--- a/Scripts/enemy_animation_component.gd
+++ b/Scripts/enemy_animation_component.gd
@@ -35,7 +35,10 @@ func _handle_death():
 	_set_anim_state(Constants.ANIM_STATE.DEATH)
 
 func _handle_damage(_value:float):
-	_set_anim_state(Constants.ANIM_STATE.HIT)
+	var tween = base_node.create_tween()
+	tween.tween_property(animated_sprite, "modulate", start_color, 0)
+	tween.tween_property(animated_sprite, "modulate", end_color, flash_duration)
+	tween.tween_callback(Callable(tween, "queue_free"))
 
 func _handle_warning(value:float):
 	var flash = 0.1

--- a/Scripts/healthbar_manager.gd
+++ b/Scripts/healthbar_manager.gd
@@ -5,6 +5,7 @@ var current_health:int = 0
 
 @export var is_player_or_boss:bool = false
 @export var boss_name:String 
+var boss_label:Label
 
 # Health bar display
 @onready var health_bar = $HealthBar
@@ -13,6 +14,7 @@ func _ready():
 	if(is_player_or_boss):
 		EventManager.add_listener(str(EventManager.EVENT_NAMES.ON_PLAYER_HEALTH_CHANGED), self, "_set_current_health")
 	else:
+		boss_label = %BossLabel
 		EventManager.add_listener(str(EventManager.EVENT_NAMES.ON_BOSS_HEALTH_CHANGED), self, "_set_boss_health")
 
 func _exit_tree():
@@ -31,6 +33,8 @@ func _cache_max_health(value:int):
 
 func _set_boss_health(params:Array):
 	if(params[0] == boss_name):
+		if(boss_label.text != boss_name):
+			boss_label.text = boss_name
 		_set_current_health(params[1])
 
 # Set current health.


### PR DESCRIPTION
# Task ID
[PDH-27](https://www.notion.so/Enemies-f1fd16e8dd1942899243798675b1b242)

# Description
1. Alt solution to enemy stacking.
2. Fix for tentacle skill not working on Support mob.
3. Gagamboy tweaks.
4. Added boss name boss to health bar.
5. Removed "hit" animation from all enemies. Reverted to flashing red instead so that it doesn't interrupt the current animations they're doing.
